### PR TITLE
Add MQTT communication

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -40,7 +40,8 @@
             "compilerPath": "/usr/bin/arm-none-eabi-g++",
             "cStandard": "c11",
             "cppStandard": "c++17",
-            "intelliSenseMode": "linux-gcc-arm64"
+            "intelliSenseMode": "linux-gcc-arm64",
+            "compileCommands": "${workspaceFolder}/build/compile_commands.json"
         }
     ],
     "version": 4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,7 +52,17 @@
         "typeinfo": "cpp",
         "*.in": "cpp",
         "fstream": "cpp",
-        "istream": "cpp"
+        "istream": "cpp",
+        "hash_map": "cpp",
+        "strstream": "cpp",
+        "complex": "cpp",
+        "cstring": "cpp",
+        "list": "cpp",
+        "iomanip": "cpp",
+        "iostream": "cpp",
+        "numbers": "cpp",
+        "sstream": "cpp",
+        "cfenv": "cpp"
     },
     "cSpell.words": [
         "ALTCP",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,7 @@
     "cSpell.words": [
         "ALTCP",
         "gpio",
+        "GPIOS",
         "INPROGRESS",
         "inpub",
         "MQTT",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ target_link_libraries(
     pico_lwip_mqtt
     pico_multicore
     pico_stdlib
+    pico_unique_id
     hardware_adc
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ target_sources(
     ${PROJECT_NAME}
     PRIVATE
         src/connectivity/dns/resolver.cpp
+        src/connectivity/mqtt/detail/context.cpp
         src/connectivity/mqtt/client.cpp
         src/connectivity/wireless/connection-status.cpp
         src/connectivity/wireless/wifi-connection.cpp

--- a/src/connectivity/dns/resolver.hpp
+++ b/src/connectivity/dns/resolver.hpp
@@ -11,5 +11,13 @@ SPDX-License-Identifier: BSD-3-Clause
 
 
 namespace dns {
+/**
+ * Resolves a FQDN or hostname to an IP address.
+ *
+ * @param[in] hostname The hostname or FQDN to be resolved.
+ * @param[in] resolved_address The resolved IP address.
+ * @param[in] timeout_ms The timeout for IP address resolution.
+ * @return True if @a hostname was resolved, false otherwise.
+ */
 bool resolve(const std::string& hostname, ip_addr_t& resolved_address, int32_t timeout_ms);
 } // namespace dns

--- a/src/connectivity/mqtt.hpp
+++ b/src/connectivity/mqtt.hpp
@@ -5,6 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #pragma once
 
 #include "connectivity/mqtt/client.hpp"
+#include "connectivity/mqtt/common.hpp"
 #include "generated/configuration.hpp"
 
 #include <pico/stdio.h>
@@ -22,6 +23,26 @@ static bool initialize(Client& client, uint64_t uid)
 
     if (!client.publish(UID_TOPIC, static_cast<const void*>(&uid), sizeof(uint64_t), mqtt::QoS::EXACTLY_ONCE, true)) {
         printf("Failed to publish %s\n", UID_TOPIC.data());
+        return false;
+    }
+
+    return true;
+}
+
+static bool publish(Client& client, std::string_view topic, const std::string& data)
+{
+    if (!client.publish(topic, static_cast<const void*>(data.c_str()), data.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
+        printf("Failed to publish %s on %s\n", data.c_str(), topic.data());
+        return false;
+    }
+
+    return true;
+}
+
+static bool publish(Client& client, std::string_view topic, uint32_t data)
+{
+    if (!client.publish(topic, static_cast<const void*>(&data), sizeof(uint32_t), mqtt::QoS::EXACTLY_ONCE, true)) {
+        printf("Failed to publish %u on %s\n", data, topic.data());
         return false;
     }
 

--- a/src/connectivity/mqtt.hpp
+++ b/src/connectivity/mqtt.hpp
@@ -14,14 +14,14 @@ SPDX-License-Identifier: BSD-3-Clause
 
 
 namespace mqtt {
-static bool initialize(Client& client, uint64_t uid)
+static bool initialize(Client& client, const std::string& uid)
 {
     if (!client.publish(VERSION_TOPIC, static_cast<const void*>(VERSION.data()), VERSION.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
         printf("Failed to publish %s\n", VERSION_TOPIC.data());
         return false;
     }
 
-    if (!client.publish(UID_TOPIC, static_cast<const void*>(&uid), sizeof(uint64_t), mqtt::QoS::EXACTLY_ONCE, true)) {
+    if (!client.publish(UID_TOPIC, static_cast<const void*>(uid.c_str()), uid.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
         printf("Failed to publish %s\n", UID_TOPIC.data());
         return false;
     }

--- a/src/connectivity/mqtt/client.hpp
+++ b/src/connectivity/mqtt/client.hpp
@@ -4,6 +4,8 @@ SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
 #pragma once
 
+#include "connectivity/mqtt/common.hpp"
+
 #include <lwip/apps/mqtt.h>
 #include <lwip/ip_addr.h>
 
@@ -38,9 +40,11 @@ public:
     bool connected() const;
     bool disconnect();
     bool publish(std::string_view topic, const void* payload, uint16_t size, QoS qos, bool retain);
-    bool subscribe(std::string_view topic);
+    bool subscribe(std::string_view topic, TopicCallback callback);
+    bool unsubscribe(std::string_view topic);
 
 private:
+    void _init();
     void _onConnectionStatusChanged(mqtt_connection_status_t status);
 
     mqtt_client_t* _mqtt;

--- a/src/connectivity/mqtt/client.hpp
+++ b/src/connectivity/mqtt/client.hpp
@@ -15,18 +15,46 @@ SPDX-License-Identifier: BSD-3-Clause
 
 
 namespace mqtt {
+/**
+ * The MQTT QoS values.
+ *
+ * @see https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/
+ */
 enum class QoS : uint8_t
 {
+    /** MQTT will deliver the message at most once. */
     AT_MOST_ONCE = 0,
+
+    /** MQTT will deliver the message at least once. */
     AT_LEAST_ONCE = 1,
+
+    /** MQTT will deliver the message exactly once. */
     EXACTLY_ONCE = 2
 };
 
 class Client
 {
 public:
+    /**
+     * Constructor
+     *
+     * @param[in] broker The MQTT Broker.
+     * @param[in] port The MQTT port on which @a broker is listening.
+     * @param[in] client_name The name of this MQTT client.
+     * @param[in] led_pin The MQTT Feedback LED pin to use.
+     */
     Client(std::string_view broker, uint16_t port, std::string_view client_name, uint8_t led_pin);
 
+    /**
+     * Constructor
+     *
+     * @param[in] broker The MQTT Broker.
+     * @param[in] port The MQTT port on which @a broker is listening.
+     * @param[in] client_name The name of this MQTT client.
+     * @param[in] user The username of this MQTT client.
+     * @param[in] password The password associated with @a user.
+     * @param[in] led_pin The MQTT Feedback LED pin to use.
+     */
     Client(std::string_view broker,
            uint16_t port,
            std::string_view client_name,
@@ -34,17 +62,64 @@ public:
            std::string_view password,
            uint8_t led_pin);
 
+    /** Destructor. */
     ~Client();
 
+    /**
+     * @return True if this client connected to MQTT, false otherwise.
+     */
     bool connect();
+
+    /**
+     * @return True if this client is connected to MQTT, false otherwise.
+     */
     bool connected() const;
+
+    /**
+     * @return True if this client disconnected from MQTT, false otherwise.
+     */
     bool disconnect();
+
+    /**
+     * Publish an MQTT message on @a topic.
+     *
+     * @param[in] topic The MQTT topic on which to publish the message.
+     * @param[in] payload The message payload.
+     * @param[in] size The size of @a payload in bytes.
+     * @param[in] qos The QoS to use for this publish.
+     * @param[in] retain True if the broker should retain this message, false otherwise.
+     * @return True if the MQTT message was published, false otherwise.
+     */
     bool publish(std::string_view topic, const void* payload, uint16_t size, QoS qos, bool retain);
+
+    /**
+     * Subscribes to an MQTT topic, @a topic, using this Client's connection.
+     *
+     * @param[in] topic The MQTT topic to subscribe to.
+     * @param[in] callback The callback to be invoked when data is available on @a topic.
+     * @return True if @a topic was subscribed to, false otherwise.
+     */
     bool subscribe(std::string_view topic, TopicCallback callback);
+
+    /**
+     * Unsubscribes from an MQTT topic, @a topic, using this Client's connection.
+     *
+     * @param[in] topic The MQTT topic to unsubscribe from.
+     * @return True if @a topic was unsubscribed from, false otherwise.
+     */
     bool unsubscribe(std::string_view topic);
 
 private:
+    /**
+     * Initializes this MQTT client.
+     */
     void _init();
+
+    /**
+     * Handler for MQTT connection status changes.
+     *
+     * @param[in] status
+     */
     void _onConnectionStatusChanged(mqtt_connection_status_t status);
 
     mqtt_client_t* _mqtt;

--- a/src/connectivity/mqtt/common.hpp
+++ b/src/connectivity/mqtt/common.hpp
@@ -1,0 +1,28 @@
+/*------------------------------------------------------------------------------
+Copyright (c) 2023 Joe Porembski
+SPDX-License-Identifier: BSD-3-Clause
+------------------------------------------------------------------------------*/
+#pragma once
+
+#include <lwip/apps/mqtt.h>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace mqtt {
+using Buffer = std::vector<uint8_t>;
+using TopicCallback = std::function<void(const std::string&, const Buffer&)>;
+using ConnectionStatusCallback = std::function<void(mqtt_connection_status_t)>;
+
+static std::string toString(const Buffer& data)
+{
+    std::string result;
+    result.resize(data.size());
+    for (size_t i = 0; i < data.size(); i++) {
+        result[i] = static_cast<char>(data[i]);
+    }
+    return result;
+}
+} // namespace mqtt

--- a/src/connectivity/mqtt/detail/context.cpp
+++ b/src/connectivity/mqtt/detail/context.cpp
@@ -1,0 +1,106 @@
+/*------------------------------------------------------------------------------
+Copyright (c) 2023 Joe Porembski
+SPDX-License-Identifier: BSD-3-Clause
+------------------------------------------------------------------------------*/
+
+#include "connectivity/mqtt/detail/context.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+
+namespace mqtt::detail {
+void ContextInterface::setConnectionStatusCallback(ConnectionStatusCallback callback)
+{
+    _connection_callback = std::move(callback);
+}
+
+void ContextInterface::onConnectionStatusChanged(mqtt_connection_status_t status)
+{
+    if (_connection_callback) {
+        _connection_callback(status);
+    }
+}
+
+void ContextInterface::subscribe(std::string_view topic, TopicCallback callback)
+{
+    std::string topic_key(topic.data(), topic.size());
+    _callbacks[topic_key] = std::move(callback);
+}
+
+void ContextInterface::unsubscribe(std::string_view topic)
+{
+    std::string topic_key(topic.data(), topic.size());
+    auto callback_iteration = _callbacks.find(topic_key);
+    if (callback_iteration != _callbacks.cend()) {
+        _callbacks.erase(callback_iteration);
+    }
+}
+
+void ContextInterface::addPendingData(const uint8_t* data, uint16_t length)
+{
+    size_t desired = _current_index + length;
+    printf("Context receiving %u bytes on %s\n", length, _pending_topic.c_str());
+    if (desired > _buffer.size()) {
+        printf("Context buffer overrun (%u available, %u provided)", _buffer.size(), desired);
+        return;
+    }
+
+    for (uint16_t i = 0; i < length; _current_index++, i++, _remaining_data--) {
+        _buffer[_current_index] = data[i];
+    }
+
+    if (_remaining_data <= 0) {
+        printf("Context received all data on %s\n", _pending_topic.c_str());
+        _push();
+    }
+}
+
+void ContextInterface::setPendingTopic(const std::string& pending_topic, uint32_t pending_data)
+{
+    printf("Context expecting %s (length: %u)\n", pending_topic.c_str(), pending_data);
+
+    _pending_topic = pending_topic;
+    _current_index = 0;
+    _remaining_data = pending_data;
+    _buffer.clear();
+    if (pending_data == 0) {
+        _push();
+    }
+
+    _buffer.resize(pending_data);
+}
+
+ContextInterface::ContextInterface()
+    : _pending_topic(), _buffer(), _current_index(0), _remaining_data(0), _callbacks(), _connection_callback()
+{}
+
+void ContextInterface::_push()
+{
+    auto callback_iteration = _callbacks.find(_pending_topic);
+    if (callback_iteration == _callbacks.cend() || !(callback_iteration->second)) {
+        printf("No callback registered for %s\n", _pending_topic.c_str());
+        return;
+    }
+
+    printf("Executing callback for %s\n", _pending_topic.c_str());
+    callback_iteration->second(_pending_topic, _buffer);
+}
+
+Context& Context::instance()
+{
+    static Context context;
+    return context;
+}
+
+ContextInterface& Context::interface()
+{
+    return _interface;
+}
+
+Context::Context() : _interface()
+{}
+} // namespace mqtt::detail

--- a/src/connectivity/mqtt/detail/context.hpp
+++ b/src/connectivity/mqtt/detail/context.hpp
@@ -4,6 +4,8 @@ SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
 #pragma once
 
+#include "connectivity/mqtt/common.hpp"
+
 #include <cstdint>
 #include <cstdio>
 #include <functional>
@@ -12,52 +14,49 @@ SPDX-License-Identifier: BSD-3-Clause
 
 
 namespace mqtt::detail {
+class ContextInterface
+{
+public:
+    ContextInterface();
+
+    void setConnectionStatusCallback(ConnectionStatusCallback callback);
+
+    void onConnectionStatusChanged(mqtt_connection_status_t status);
+
+    void subscribe(std::string_view topic, TopicCallback callback);
+
+    void unsubscribe(std::string_view topic);
+
+    void addPendingData(const uint8_t* data, uint16_t length);
+
+    void setPendingTopic(const std::string& pending_topic, uint32_t pending_data);
+
+private:
+    void _push();
+
+    std::string _pending_topic;
+    Buffer _buffer;
+    size_t _current_index;
+    ssize_t _remaining_data;
+    std::unordered_map<std::string, TopicCallback> _callbacks;
+    ConnectionStatusCallback _connection_callback;
+};
+
 class Context
 {
 public:
-    static Context& context()
-    {
-        static Context instance;
-        return instance;
-    }
+    static Context& instance();
 
-    void setPendingTopic(const std::string& pending_topic, uint32_t pending_data)
-    {
-        printf("Context expecting %s (length: %u)\n", pending_topic.c_str(), pending_data);
-
-        _pending_topic = pending_topic;
-        _current_index = 0;
-        _buffer.clear();
-        if (pending_data == 0) {
-            _push();
-        }
-
-        _buffer.resize(pending_data);
-    }
-
-    void addPendingData(const uint8_t* data, uint16_t length)
-    {
-        size_t desired = _current_index + length;
-        printf("Context receiving %u bytes on %s\n", length, _pending_topic.c_str());
-        if (desired > _buffer.size()) {
-            printf("Context buffer overrun (%u available, %u provided)", _buffer.size(), desired);
-            return;
-        }
-
-        for (uint16_t i = 0; i < length; _current_index++, i++) {
-            _buffer[_current_index] = data[i];
-        }
-    }
+    ContextInterface& interface();
 
 private:
-    Context()
-    {}
+    Context();
 
-    void _push()
-    {}
-
-    std::string _pending_topic;
-    std::vector<uint8_t> _buffer;
-    size_t _current_index;
+    ContextInterface _interface;
 };
+
+inline ContextInterface& context()
+{
+    return Context::instance().interface();
+}
 } // namespace mqtt::detail

--- a/src/connectivity/mqtt/detail/context.hpp
+++ b/src/connectivity/mqtt/detail/context.hpp
@@ -14,24 +14,65 @@ SPDX-License-Identifier: BSD-3-Clause
 
 
 namespace mqtt::detail {
+/**
+ * An interface for modifying the MQTT context.
+ */
 class ContextInterface
 {
 public:
+    /** Constructor. */
     ContextInterface();
 
+    /**
+     * Sets the callback for connectivity status changes.
+     *
+     * @param[in] callback The callback to use when MQTT connectivity changes.
+     */
     void setConnectionStatusCallback(ConnectionStatusCallback callback);
 
+    /**
+     * Handler for changes to the MQTT connectivity status.
+     *
+     * @note This should not be called by MQTT clients.
+     * @param[in] status The MQTT connection status.
+     */
     void onConnectionStatusChanged(mqtt_connection_status_t status);
 
+    /**
+     * Subscribes to a MQTT topic.
+     *
+     * @param[in] topic The topic to be subscribed to.
+     * @param[in] callback The callback to be invoked when a complete message has been received on @a topic.
+     */
     void subscribe(std::string_view topic, TopicCallback callback);
 
+    /**
+     * Unsubscribes from a MQTT topic.
+     *
+     * @param[in] topic The topic to be unsubscribed from.
+     */
     void unsubscribe(std::string_view topic);
 
+    /**
+     * Adds data to the pending MQTT topic.
+     *
+     * @param[in] data The buffer of data to be added.
+     * @param[in] length The number of bytes in the data buffer.
+     */
     void addPendingData(const uint8_t* data, uint16_t length);
 
+    /**
+     * Sets the topic on which the MQTT stack is about to receive data.
+     *
+     * @param[in] pending_topic The topic on which data is about to be received.
+     * @param[in] pending_data The amount of data to be received.
+     */
     void setPendingTopic(const std::string& pending_topic, uint32_t pending_data);
 
 private:
+    /**
+     * Pushes pending MQTT data to any subscribed clients.
+     */
     void _push();
 
     std::string _pending_topic;
@@ -42,19 +83,34 @@ private:
     ConnectionStatusCallback _connection_callback;
 };
 
+/**
+ * The MQTT context, responsible for routing feedback from the MQTT stack to subscribed classes.
+ *
+ * @note This class is a singleton.
+ */
 class Context
 {
 public:
+    /**
+     * @return The MQTT context.
+     */
     static Context& instance();
 
+    /**
+     * @return The interface for modifying the MQTT context.
+     */
     ContextInterface& interface();
 
 private:
+    /** Constructor. */
     Context();
 
     ContextInterface _interface;
 };
 
+/**
+ * @return The MQTT context.
+ */
 inline ContextInterface& context()
 {
     return Context::instance().interface();

--- a/src/controllers/constants.hpp
+++ b/src/controllers/constants.hpp
@@ -14,4 +14,4 @@ SPDX-License-Identifier: BSD-3-Clause
 inline constexpr float DEFAULT_TEMPERATURE = FLT_MIN;
 inline constexpr float MINIMUM_TARGET_TEMPERATURE = FLT_MIN;
 inline constexpr float MINIMUM_HYSTERESIS = 1.0f;
-inline constexpr uint32_t MINIMUM_OFF_TIME_MS = 30 * 1000;
+inline constexpr uint32_t MINIMUM_OFF_TIME_MS = 60 * 1000;

--- a/src/controllers/heater.hpp
+++ b/src/controllers/heater.hpp
@@ -8,19 +8,55 @@ SPDX-License-Identifier: BSD-3-Clause
 
 
 namespace controllers {
+/**
+ * A generic controller for a Heating element.
+ */
 class Heater
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param[in] control_pin The pin assigned to the Heater Relay.
+     * @param[in] feedback_pin The pin assigned to the Heater Feedback LED.
+     * @param[in] hysteresis The hysteresis in degrees Celsius.
+     * @param[in] max_on_time The maximum amount of time the heater can be on in milliseconds.
+     */
     Heater(uint8_t control_pin, uint8_t feedback_pin, float hysteresis, uint64_t max_on_time);
 
+    /**
+     * @return True if the heater is on, false otherwise.
+     */
     bool isOn() const;
+
+    /**
+     * @return The current target temperature in degrees Celsius.
+     */
     float targetTemperature() const;
 
+    /**
+     * Sets the target temperature for the heater.
+     *
+     * @param[in] target_temperature The desired target temperature in degrees Celsius.
+     */
     void setTargetTemperature(float target_temperature);
+
+    /**
+     * Updates the Heater's control based on the provided temperature.
+     *
+     * @param[in] actual_temperature The actual temperature of the environment in degrees Celsius.
+     */
     void update(float actual_temperature);
 
 private:
+    /**
+     * Turn the Heater off.
+     */
     void _off();
+
+    /**
+     * Turn the Heater on.
+     */
     void _on();
 
     const uint64_t _max_on_time;

--- a/src/generated/configuration.hpp.in
+++ b/src/generated/configuration.hpp.in
@@ -43,5 +43,11 @@ inline constexpr uint8_t SYSTEM_LED_PIN = @SYSTEM_LED_PIN@;
 inline constexpr std::string_view PROGRAM_TOPIC = "@DEVICE_NAME@";
 inline constexpr std::string_view VERSION_TOPIC = "@DEVICE_NAME@/version";
 inline constexpr std::string_view UID_TOPIC = "@DEVICE_NAME@/uid";
+inline constexpr std::string_view BOARD_TEMPERATURE_TOPIC = "@DEVICE_NAME@/board/temperature";
+inline constexpr std::string_view HUMIDITY_TOPIC = "@DEVICE_NAME@/container/humidity";
+inline constexpr std::string_view TEMPERATURE_TOPIC = "@DEVICE_NAME@/container/temperature";
+inline constexpr std::string_view TARGET_TEMPERATURE_TOPIC = "@DEVICE_NAME@/container/target_temperature";
+inline constexpr std::string_view SET_TARGET_TEMPERATURE_TOPIC = "@DEVICE_NAME@/container/target_temperature/set";
+inline constexpr std::string_view HEATER_TOPIC = "@DEVICE_NAME@/container/heater";
 
 // clang-format on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,8 +18,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <pico/stdlib.h>
 #include <pico/util/queue.h>
 
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 
 
 inline constexpr float HEATER_HYSTERESIS = 5.0f;
@@ -84,13 +86,77 @@ feedback_entry getMostRecentData()
     return data;
 }
 
-void initialize()
+static void publish(mqtt::Client& client, const feedback_entry& data)
+{
+    std::string board_temperature = std::to_string(data.board_temperature);
+    std::string container_temperature = std::to_string(data.container_temperature);
+    std::string container_humidity = std::to_string(data.container_humidity);
+    std::string target_temperature = std::to_string(data.target_temperature);
+
+    mqtt::publish(client, BOARD_TEMPERATURE_TOPIC, board_temperature);
+    mqtt::publish(client, HUMIDITY_TOPIC, container_humidity);
+    mqtt::publish(client, TEMPERATURE_TOPIC, container_temperature);
+    mqtt::publish(client, HEATER_TOPIC, static_cast<uint32_t>(data.heater_on));
+    mqtt::publish(client, TARGET_TEMPERATURE_TOPIC, target_temperature);
+}
+
+static void initialize()
 {
     stdio_init_all();
     adc_init();
 
     queue_init(&feedback_queue, sizeof(feedback_entry), QUEUE_SIZE);
     queue_init(&request_queue, sizeof(request_entry), QUEUE_SIZE);
+
+    gpio_init(SYSTEM_LED_PIN);
+    gpio_set_dir(SYSTEM_LED_PIN, GPIO_OUT);
+    gpio_put(SYSTEM_LED_PIN, ON);
+}
+
+static void onSetTargetTemperatureReceived(const std::string& topic, const mqtt::Buffer& data)
+{
+    errno = 0;
+    request_entry set_request;
+    std::string value = mqtt::toString(data);
+    set_request.target_temperature = strtof(value.c_str(), NULL);
+
+    if (errno) {
+        printf("Failed to handle %s: %u\n", topic.c_str(), errno);
+        return;
+    }
+
+    printf("Received request to set target temperature to %.1fC\n", set_request.target_temperature);
+    queue_add_blocking(&request_queue, &set_request);
+}
+
+static bool initialize_mqtt(mqtt::Client& client, uint64_t board_id)
+{
+    if (!mqtt::initialize(client, board_id)) {
+        printf("Failed to initialize MQTT\n");
+        return false;
+    }
+
+    if (!client.subscribe(SET_TARGET_TEMPERATURE_TOPIC, onSetTargetTemperatureReceived)) {
+        printf("Failed to subscribe to %s\n", SET_TARGET_TEMPERATURE_TOPIC.data());
+        return false;
+    }
+
+    printf("Successfully initialized MQTT\n");
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    initialize();
+
+    uint64_t board_id = systemIdentifier();
+    uint32_t count = 0;
+    bool mqtt_initialized = false;
+
+    WifiConnection wifi(SSID, PASSPHRASE);
+    mqtt::Client mqtt(MQTT_BROKER, CONFIGURED_MQTT_PORT, DEVICE_NAME);
+    DHT sensor(DHTType::DHT22, DHT_DATA_PIN, DHT_FEEDBACK_PIN);
+    sensors::Board board;
 
     gpio_init(SYSTEM_LED_PIN);
     gpio_set_dir(SYSTEM_LED_PIN, GPIO_OUT);
@@ -121,12 +187,13 @@ int main(int argc, char** argv)
 
         if (!mqtt_initialized) {
             printf("Initializing MQTT...\n");
-            mqtt_initialized = mqtt::initialize(mqtt, board_id);
+            mqtt_initialized = initialize_mqtt(mqtt, board_id);
             sleep_ms(COMMUNICATION_PERIOD_MS);
             continue;
         }
 
         feedback_entry data = getMostRecentData();
+        publish(mqtt, data);
 
         printf("\n----------------- [%u]\n", count);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,24 +154,6 @@ int main(int argc, char** argv)
     bool mqtt_initialized = false;
 
     WifiConnection wifi(SSID, PASSPHRASE);
-    mqtt::Client mqtt(MQTT_BROKER, CONFIGURED_MQTT_PORT, DEVICE_NAME);
-    DHT sensor(DHTType::DHT22, DHT_DATA_PIN, DHT_FEEDBACK_PIN);
-    sensors::Board board;
-
-    gpio_init(SYSTEM_LED_PIN);
-    gpio_set_dir(SYSTEM_LED_PIN, GPIO_OUT);
-    gpio_put(SYSTEM_LED_PIN, ON);
-}
-
-int main(int argc, char** argv)
-{
-    initialize();
-
-    uint64_t board_id = systemIdentifier();
-    uint32_t count = 0;
-    bool mqtt_initialized = false;
-
-    WifiConnection wifi(SSID, PASSPHRASE);
     mqtt::Client mqtt(MQTT_BROKER, CONFIGURED_MQTT_PORT, DEVICE_NAME, MQTT_FEEDBACK_PIN);
 
     multicore_launch_core1(controlLoop);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <pico/multicore.h>
 #include <pico/stdio.h>
 #include <pico/stdlib.h>
+#include <pico/unique_id.h>
 #include <pico/util/queue.h>
 
 #include <cerrno>
@@ -24,7 +25,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <functional>
 
 
-inline constexpr float HEATER_HYSTERESIS = 5.0f;
+inline constexpr float HEATER_HYSTERESIS = 2.5f;
 inline constexpr uint64_t HEATER_MAX_ON_TIME_MS = 10 * 60 * 1000;
 inline constexpr uint32_t DATA_PERIOD_MS = 10000;
 inline constexpr uint32_t COMMUNICATION_PERIOD_MS = 10000;
@@ -129,7 +130,7 @@ static void onSetTargetTemperatureReceived(const std::string& topic, const mqtt:
     queue_add_blocking(&request_queue, &set_request);
 }
 
-static bool initialize_mqtt(mqtt::Client& client, uint64_t board_id)
+static bool initialize_mqtt(mqtt::Client& client, const std::string& board_id)
 {
     if (!mqtt::initialize(client, board_id)) {
         printf("Failed to initialize MQTT\n");
@@ -148,8 +149,7 @@ static bool initialize_mqtt(mqtt::Client& client, uint64_t board_id)
 int main(int argc, char** argv)
 {
     initialize();
-
-    uint64_t board_id = systemIdentifier();
+    std::string board_id = systemIdentifier();
     uint32_t count = 0;
     bool mqtt_initialized = false;
 

--- a/src/sensors/dht.cpp
+++ b/src/sensors/dht.cpp
@@ -41,7 +41,7 @@ DHT::DHT(DHTType type, uint8_t data_pin, uint8_t feedback_led_pin)
         gpio_put(_feedback_led_pin, LOW);
     }
     else {
-        printf("Feedback disabled, LED PIN %u is invalid\n", _feedback_led_pin);
+        printf("DHT Feedback disabled, LED PIN %u is invalid\n", _feedback_led_pin);
     }
 
     gpio_init(_data_pin);

--- a/src/sensors/dht.cpp
+++ b/src/sensors/dht.cpp
@@ -194,8 +194,6 @@ void DHT::_start()
      * Although some of the reference integration code provided by Waveshare show holding the data line low for longer.
      * Basic flow here is to pull down the data line for 20 milliseconds then high for 20-40 microseconds.
      */
-    printf("Starting read on DHT sensor connected to pin %lu\n", _data_pin);
-
     gpio_set_dir(_data_pin, GPIO_OUT);
     gpio_put(_data_pin, LOW);
     sleep_ms(READ_REQUEST_LOW_TIME_MS);

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -13,7 +13,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <pico/unique_id.h>
 
 #include <cstdint>
+#include <cstring>
 
+
+inline constexpr size_t UID_SIZE = 2 * PICO_UNIQUE_BOARD_ID_SIZE_BYTES + 1;
 
 uint64_t microseconds()
 {
@@ -25,17 +28,11 @@ uint64_t milliseconds()
     return to_us_since_boot(get_absolute_time()) / 1000;
 }
 
-uint64_t systemIdentifier()
+std::string systemIdentifier()
 {
-    pico_unique_board_id_t board_id;
-    pico_get_unique_board_id(&board_id);
-
-    uint64_t uid = 0;
-    for (size_t i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES; i++) {
-        uid <<= BITS_IN_BYTE;
-        uid |= board_id.id[i];
-    }
-
+    char uid[UID_SIZE];
+    std::memset(uid, 0, UID_SIZE);
+    pico_get_unique_board_id_string(uid, UID_SIZE);
     return uid;
 }
 

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -9,6 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <pico/types.h>
 
 #include <cstdint>
+#include <vector>
 
 
 inline constexpr float C_TO_F_SCALE = 9.0 / 5.0;

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -26,6 +26,9 @@ uint64_t microseconds();
  */
 uint64_t milliseconds();
 
+/**
+ * @return The unique identifier of this system.
+ */
 std::string systemIdentifier();
 
 /**

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -9,6 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <pico/types.h>
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 
@@ -25,7 +26,7 @@ uint64_t microseconds();
  */
 uint64_t milliseconds();
 
-uint64_t systemIdentifier();
+std::string systemIdentifier();
 
 /**
  * Waits on the to become @a desired_state.


### PR DESCRIPTION
This commit adds all the expected MQTT topics for both publishing
and subscribing. All topics are relative to the device name as follows:

Published Topics: 
* `board/temperature`: The current temperature of the Pico.
* `container/humidity`: The current humidity of the container.
* `container/temperature`: The current temperature of the container.
* `container/target_temperature`: The current container target temperature.
* `container/heater`: The current state of the heater.

Subscribed Topics:
* `container/target_temperature/set`: Sets the container target temperature.

It also standardizes the standard pin assignments based on the PCB
diagram provided in a2274db4.

Finally, this commit also updates how the heater control works to use
a multi-core setup.

Closes #7 