### PR TITLE
Create MQTT topics at run-time

### DIFF
--- a/src/connectivity/mqtt.hpp
+++ b/src/connectivity/mqtt.hpp
@@ -16,33 +16,36 @@ SPDX-License-Identifier: BSD-3-Clause
 namespace mqtt {
 static bool initialize(Client& client, const std::string& uid)
 {
-    if (!client.publish(VERSION_TOPIC, static_cast<const void*>(VERSION.data()), VERSION.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
-        printf("Failed to publish %s\n", VERSION_TOPIC.data());
+    char mqtt_topic[TOPIC_BUFFER_SIZE];
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, VERSION_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    if (!client.publish(mqtt_topic, static_cast<const void*>(VERSION.data()), VERSION.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
+        printf("Failed to publish %s\n", mqtt_topic);
         return false;
     }
 
-    if (!client.publish(UID_TOPIC, static_cast<const void*>(uid.c_str()), uid.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
-        printf("Failed to publish %s\n", UID_TOPIC.data());
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, UID_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    if (!client.publish(mqtt_topic, static_cast<const void*>(uid.c_str()), uid.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
+        printf("Failed to publish %s\n", mqtt_topic);
         return false;
     }
 
     return true;
 }
 
-static bool publish(Client& client, std::string_view topic, const std::string& data)
+static bool publish(Client& client, const char* topic, const std::string& data)
 {
     if (!client.publish(topic, static_cast<const void*>(data.c_str()), data.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
-        printf("Failed to publish %s on %s\n", data.c_str(), topic.data());
+        printf("Failed to publish %s on %s\n", data.c_str(), topic);
         return false;
     }
 
     return true;
 }
 
-static bool publish(Client& client, std::string_view topic, uint32_t data)
+static bool publish(Client& client, const char* topic, uint32_t data)
 {
     if (!client.publish(topic, static_cast<const void*>(&data), sizeof(uint32_t), mqtt::QoS::EXACTLY_ONCE, true)) {
-        printf("Failed to publish %u on %s\n", data, topic.data());
+        printf("Failed to publish %u on %s\n", data, topic);
         return false;
     }
 

--- a/src/connectivity/mqtt/client.cpp
+++ b/src/connectivity/mqtt/client.cpp
@@ -79,7 +79,7 @@ static void onRequestComplete(void* arg, err_t error)
 namespace mqtt {
 inline constexpr uint32_t DNS_TIMEOUT_MS = 10000;
 
-Client::Client(std::string_view broker, uint16_t port, std::string_view client_name, uint8_t led_pin)
+Client::Client(const std::string& broker, uint16_t port, const std::string& client_name, uint8_t led_pin)
     : _mqtt(mqtt_client_new()),
       _led_pin(led_pin),
       _broker(broker),
@@ -105,11 +105,11 @@ Client::Client(std::string_view broker, uint16_t port, std::string_view client_n
     _init();
 }
 
-Client::Client(std::string_view broker,
+Client::Client(const std::string& broker,
                uint16_t port,
-               std::string_view client_name,
-               std::string_view user,
-               std::string_view password,
+               const std::string& client_name,
+               const std::string& user,
+               const std::string& password,
                uint8_t led_pin)
     : _mqtt(mqtt_client_new()),
       _led_pin(led_pin),
@@ -142,6 +142,11 @@ Client::~Client()
     mqtt_disconnect(_mqtt);
     mqtt_client_free(_mqtt);
     cyw43_arch_lwip_end();
+}
+
+const std::string& Client::deviceName() const
+{
+    return _name;
 }
 
 bool Client::connected() const
@@ -178,34 +183,34 @@ bool Client::disconnect()
     return true;
 }
 
-bool Client::publish(std::string_view topic, const void* payload, uint16_t size, QoS qos, bool retain)
+bool Client::publish(const char* topic, const void* payload, uint16_t size, QoS qos, bool retain)
 {
     uint8_t qos_value = static_cast<uint8_t>(qos);
     uint8_t retain_value = static_cast<uint8_t>(retain);
 
     cyw43_arch_lwip_begin();
-    err_t error = mqtt_publish(_mqtt, topic.data(), payload, size, qos_value, retain_value, onRequestComplete, NULL);
+    err_t error = mqtt_publish(_mqtt, topic, payload, size, qos_value, retain_value, onRequestComplete, NULL);
     cyw43_arch_lwip_end();
 
     if (error != ERR_OK) {
-        printf("Publish of %s unsuccessful: %s\n", topic.data(), lwip_strerr(error));
+        printf("Publish of %s unsuccessful: %s\n", topic, lwip_strerr(error));
         return false;
     }
     return true;
 }
 
-bool Client::subscribe(std::string_view topic, TopicCallback callback)
+bool Client::subscribe(const char* topic, TopicCallback callback)
 {
     uint8_t qos_value = static_cast<uint8_t>(QoS::AT_LEAST_ONCE);
     detail::context().subscribe(topic, callback);
-    err_t error = mqtt_subscribe(_mqtt, topic.data(), qos_value, onRequestComplete, NULL);
+    err_t error = mqtt_subscribe(_mqtt, topic, qos_value, onRequestComplete, NULL);
     return error == ERR_OK;
 }
 
-bool Client::unsubscribe(std::string_view topic)
+bool Client::unsubscribe(const char* topic)
 {
     detail::context().unsubscribe(topic);
-    err_t error = mqtt_unsubscribe(_mqtt, topic.data(), onRequestComplete, NULL);
+    err_t error = mqtt_unsubscribe(_mqtt, topic, onRequestComplete, NULL);
     return error == ERR_OK;
 }
 

--- a/src/connectivity/mqtt/client.hpp
+++ b/src/connectivity/mqtt/client.hpp
@@ -43,7 +43,7 @@ public:
      * @param[in] client_name The name of this MQTT client.
      * @param[in] led_pin The MQTT Feedback LED pin to use.
      */
-    Client(std::string_view broker, uint16_t port, std::string_view client_name, uint8_t led_pin);
+    Client(const std::string& broker, uint16_t port, const std::string& client_name, uint8_t led_pin);
 
     /**
      * Constructor
@@ -55,15 +55,20 @@ public:
      * @param[in] password The password associated with @a user.
      * @param[in] led_pin The MQTT Feedback LED pin to use.
      */
-    Client(std::string_view broker,
+    Client(const std::string& broker,
            uint16_t port,
-           std::string_view client_name,
-           std::string_view user,
-           std::string_view password,
+           const std::string& client_name,
+           const std::string& user,
+           const std::string& password,
            uint8_t led_pin);
 
     /** Destructor. */
     ~Client();
+
+    /**
+     * @return The device name used by this client.
+     */
+    const std::string& deviceName() const;
 
     /**
      * @return True if this client connected to MQTT, false otherwise.
@@ -90,7 +95,7 @@ public:
      * @param[in] retain True if the broker should retain this message, false otherwise.
      * @return True if the MQTT message was published, false otherwise.
      */
-    bool publish(std::string_view topic, const void* payload, uint16_t size, QoS qos, bool retain);
+    bool publish(const char* topic, const void* payload, uint16_t size, QoS qos, bool retain);
 
     /**
      * Subscribes to an MQTT topic, @a topic, using this Client's connection.
@@ -99,7 +104,7 @@ public:
      * @param[in] callback The callback to be invoked when data is available on @a topic.
      * @return True if @a topic was subscribed to, false otherwise.
      */
-    bool subscribe(std::string_view topic, TopicCallback callback);
+    bool subscribe(const char* topic, TopicCallback callback);
 
     /**
      * Unsubscribes from an MQTT topic, @a topic, using this Client's connection.
@@ -107,7 +112,7 @@ public:
      * @param[in] topic The MQTT topic to unsubscribe from.
      * @return True if @a topic was unsubscribed from, false otherwise.
      */
-    bool unsubscribe(std::string_view topic);
+    bool unsubscribe(const char* topic);
 
 private:
     /**

--- a/src/generated/configuration.hpp.in
+++ b/src/generated/configuration.hpp.in
@@ -1,6 +1,7 @@
 // clang-format off
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 
 /** Port of the device receiving the data (Pico W) */
@@ -28,14 +29,15 @@ inline constexpr uint8_t HEATER_CONTROL_PIN = @HEATER_CONTROL_PIN@;
 inline constexpr uint8_t SYSTEM_LED_PIN = @SYSTEM_LED_PIN@;
 
 
-inline constexpr std::string_view PROGRAM_TOPIC = "@DEVICE_NAME@";
-inline constexpr std::string_view VERSION_TOPIC = "@DEVICE_NAME@/version";
-inline constexpr std::string_view UID_TOPIC = "@DEVICE_NAME@/uid";
-inline constexpr std::string_view BOARD_TEMPERATURE_TOPIC = "@DEVICE_NAME@/board/temperature";
-inline constexpr std::string_view HUMIDITY_TOPIC = "@DEVICE_NAME@/container/humidity";
-inline constexpr std::string_view TEMPERATURE_TOPIC = "@DEVICE_NAME@/container/temperature";
-inline constexpr std::string_view TARGET_TEMPERATURE_TOPIC = "@DEVICE_NAME@/container/target_temperature";
-inline constexpr std::string_view SET_TARGET_TEMPERATURE_TOPIC = "@DEVICE_NAME@/container/target_temperature/set";
-inline constexpr std::string_view HEATER_TOPIC = "@DEVICE_NAME@/container/heater";
+inline constexpr size_t TOPIC_BUFFER_SIZE = UINT8_MAX;
+inline constexpr std::string_view PROGRAM_TOPIC_FORMAT = "%s";
+inline constexpr std::string_view VERSION_TOPIC_FORMAT = "%s/version";
+inline constexpr std::string_view UID_TOPIC_FORMAT = "%s/uid";
+inline constexpr std::string_view BOARD_TEMPERATURE_TOPIC_FORMAT = "%s/board/temperature";
+inline constexpr std::string_view HUMIDITY_TOPIC_FORMAT = "%s/container/humidity";
+inline constexpr std::string_view TEMPERATURE_TOPIC_FORMAT = "%s/container/temperature";
+inline constexpr std::string_view TARGET_TEMPERATURE_TOPIC_FORMAT = "%s/container/target_temperature";
+inline constexpr std::string_view SET_TARGET_TEMPERATURE_TOPIC_FORMAT = "%s/container/target_temperature/set";
+inline constexpr std::string_view HEATER_TOPIC_FORMAT = "%s/container/heater";
 
 // clang-format on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,11 +94,21 @@ static void publish(mqtt::Client& client, const feedback_entry& data)
     std::string container_humidity = std::to_string(data.container_humidity);
     std::string target_temperature = std::to_string(data.target_temperature);
 
-    mqtt::publish(client, BOARD_TEMPERATURE_TOPIC, board_temperature);
-    mqtt::publish(client, HUMIDITY_TOPIC, container_humidity);
-    mqtt::publish(client, TEMPERATURE_TOPIC, container_temperature);
-    mqtt::publish(client, HEATER_TOPIC, static_cast<uint32_t>(data.heater_on));
-    mqtt::publish(client, TARGET_TEMPERATURE_TOPIC, target_temperature);
+    char mqtt_topic[TOPIC_BUFFER_SIZE];
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, BOARD_TEMPERATURE_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    mqtt::publish(client, mqtt_topic, board_temperature);
+
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, HUMIDITY_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    mqtt::publish(client, mqtt_topic, container_humidity);
+
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, TEMPERATURE_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    mqtt::publish(client, mqtt_topic, container_temperature);
+
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, HEATER_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    mqtt::publish(client, mqtt_topic, static_cast<uint32_t>(data.heater_on));
+
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, TARGET_TEMPERATURE_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    mqtt::publish(client, mqtt_topic, target_temperature);
 }
 
 static void initialize()
@@ -137,8 +147,10 @@ static bool initialize_mqtt(mqtt::Client& client, const std::string& board_id)
         return false;
     }
 
-    if (!client.subscribe(SET_TARGET_TEMPERATURE_TOPIC, onSetTargetTemperatureReceived)) {
-        printf("Failed to subscribe to %s\n", SET_TARGET_TEMPERATURE_TOPIC.data());
+    char mqtt_topic[TOPIC_BUFFER_SIZE];
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, SET_TARGET_TEMPERATURE_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    if (!client.subscribe(mqtt_topic, onSetTargetTemperatureReceived)) {
+        printf("Failed to subscribe to %s\n", mqtt_topic);
         return false;
     }
 


### PR DESCRIPTION
This commit is a follow-on from #13 that removes the need to have
MQTT topics compile-time constants. This is done by converting the
previous constants into format strings and using `snprintf` to create
the MQTT topic.