### PR TITLE
Update heater status value

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ a binary blob and load in the Pico's flash. The Pico should be hooked up to the 
 The dryer publishes a collection fo MQTT topics for monitoring the status of the dryer. All topics are relative
 to the device name (i.e. if the device is named `daryl`, the container humidity will be available on `daryl/container/humidity`).
 
-| Topic                          | Description                                                                   | Data Type |
-| ------------------------------ | ----------------------------------------------------------------------------- | --------- |
-| `container/humidity`           | The current humidity within the container, as a percentage.                   | Float     |
-| `container/temperature`        | The current temperature within the container, in degrees Celsius.             | Float     |
-| `container/target_temperature` | The desired temperature within the container, in degrees Celsius.             | Float     |
-| `container/heater`             | The current state of the heater. Will be non-zero if it is on, `0` otherwise. | Integer   |
+| Topic                          | Description                                                                 | Data Type |
+| ------------------------------ | --------------------------------------------------------------------------- | --------- |
+| `container/humidity`           | The current humidity within the container, as a percentage.                 | Float     |
+| `container/temperature`        | The current temperature within the container, in degrees Celsius.           | Float     |
+| `container/target_temperature` | The desired temperature within the container, in degrees Celsius.           | Float     |
+| `container/heater`             | The current state of the heater. Will be "on" if it is on, "off" otherwise. | String    |
 
 The dryer subscribes to the following MQTT topics for command/control of the dryer:
 

--- a/src/controllers/heater.hpp
+++ b/src/controllers/heater.hpp
@@ -5,6 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 
 namespace controllers {
@@ -14,6 +15,12 @@ namespace controllers {
 class Heater
 {
 public:
+    /** Human readable string for the Heater ON state. */
+    static constexpr std::string_view ON = "on";
+
+    /** Human readable string for the Heater OFF state. */
+    static constexpr std::string_view OFF = "off";
+
     /**
      * Constructor.
      *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <cstdint>
 #include <cstdio>
 #include <functional>
+#include <string_view>
 
 
 inline constexpr float HEATER_HYSTERESIS = 2.5f;
@@ -105,7 +106,12 @@ static void publish(mqtt::Client& client, const feedback_entry& data)
     mqtt::publish(client, mqtt_topic, container_temperature);
 
     snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, HEATER_TOPIC_FORMAT.data(), client.deviceName().c_str());
-    mqtt::publish(client, mqtt_topic, static_cast<uint32_t>(data.heater_on));
+    if (data.heater_on) {
+        mqtt::publish(client, mqtt_topic, controllers::Heater::ON.data());
+    }
+    else {
+        mqtt::publish(client, mqtt_topic, controllers::Heater::OFF.data());
+    }
 
     snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, TARGET_TEMPERATURE_TOPIC_FORMAT.data(), client.deviceName().c_str());
     mqtt::publish(client, mqtt_topic, target_temperature);


### PR DESCRIPTION
This commit changes the value of `container/heater` from an integer
to a string.

Closes #16 