### PR TITLE
Improve wireless capabilities

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,6 +73,7 @@
         "MQTT",
         "multicore",
         "netif",
+        "NOIP",
         "Pico",
         "picocfg",
         "picoload",

--- a/src/connectivity/constants.hpp
+++ b/src/connectivity/constants.hpp
@@ -13,11 +13,12 @@ SPDX-License-Identifier: BSD-3-Clause
 inline constexpr uint32_t WIFI_TIMEOUT_MS = 30000;
 inline constexpr uint32_t POLL_WAIT_TIME_MS = 2000;
 inline constexpr std::string_view WIFI_STATUS_CONNECTED = "CONNECTED";
-inline constexpr std::string_view WIFI_STATUS_WIFI_CONNECTING = "WIFI_CONNECTING";
-inline constexpr std::string_view WIFI_STATUS_CONNECTING_TO_SERVER = "CONNECTING_TO_SERVER";
-inline constexpr std::string_view WIFI_STATUS_INITIALIZATION_FAILURE = "INITIALIZATION_FAILURE";
-inline constexpr std::string_view WIFI_STATUS_WIFI_CONNECTION_FAILURE = "WIFI_CONNECTION_FAILURE";
-inline constexpr std::string_view WIFI_STATUS_SERVER_CONNECTION_FAILURE = "SERVER_CONNECTION_FAILURE";
+inline constexpr std::string_view WIFI_STATUS_CONNECTING = "CONNECTING";
+inline constexpr std::string_view WIFI_STATUS_CONNECTED_NO_IP = "CONNECTED_NO_IP";
+inline constexpr std::string_view WIFI_STATUS_NOT_CONNECTED = "NOT_CONNECTED";
+inline constexpr std::string_view WIFI_STATUS_FAILURE = "FAILURE";
+inline constexpr std::string_view WIFI_STATUS_SSID_NOT_FOUND = "SSID_NOT_FOUND";
+inline constexpr std::string_view WIFI_STATUS_AUTHENTICATION_FAILURE = "AUTHENTICATION_FAILURE";
 inline constexpr std::string_view WIFI_STATUS_UNKNOWN = "UNKNOWN";
 inline constexpr std::string_view UNKNOWN_IP = "-";
 

--- a/src/connectivity/wireless/connection-status.cpp
+++ b/src/connectivity/wireless/connection-status.cpp
@@ -15,16 +15,18 @@ std::string_view toString(ConnectionStatus status)
     switch (status) {
     case ConnectionStatus::CONNECTED:
         return WIFI_STATUS_CONNECTED;
-    case ConnectionStatus::WIFI_CONNECTING:
-        return WIFI_STATUS_WIFI_CONNECTING;
-    case ConnectionStatus::CONNECTING_TO_SERVER:
-        return WIFI_STATUS_CONNECTING_TO_SERVER;
-    case ConnectionStatus::WIFI_CONNECTION_FAILURE:
-        return WIFI_STATUS_WIFI_CONNECTION_FAILURE;
-    case ConnectionStatus::INITIALIZATION_FAILURE:
-        return WIFI_STATUS_INITIALIZATION_FAILURE;
-    case ConnectionStatus::SERVER_CONNECTION_FAILURE:
-        return WIFI_STATUS_SERVER_CONNECTION_FAILURE;
+    case ConnectionStatus::CONNECTING:
+        return WIFI_STATUS_CONNECTING;
+    case ConnectionStatus::CONNECTED_NO_IP:
+        return WIFI_STATUS_CONNECTED_NO_IP;
+    case ConnectionStatus::FAILURE:
+        return WIFI_STATUS_FAILURE;
+    case ConnectionStatus::NOT_CONNECTED:
+        return WIFI_STATUS_NOT_CONNECTED;
+    case ConnectionStatus::AUTHENTICATION_FAILURE:
+        return WIFI_STATUS_AUTHENTICATION_FAILURE;
+    case ConnectionStatus::SSID_NOT_FOUND:
+        return WIFI_STATUS_SSID_NOT_FOUND;
     default:
         return WIFI_STATUS_UNKNOWN;
     }

--- a/src/connectivity/wireless/connection-status.hpp
+++ b/src/connectivity/wireless/connection-status.hpp
@@ -8,14 +8,15 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <string_view>
 
 /** Enumeration of the possible status values of a Wireless Connection */
-enum class ConnectionStatus : uint8_t
+enum class ConnectionStatus : int8_t
 {
-    CONNECTED = 0x00,
-    WIFI_CONNECTING,
-    CONNECTING_TO_SERVER,
-    INITIALIZATION_FAILURE = 0xC0,
-    WIFI_CONNECTION_FAILURE,
-    SERVER_CONNECTION_FAILURE
+    NOT_CONNECTED = 0,          ///< Link is down
+    CONNECTING = 1,             ///< Connecting to Wifi.
+    CONNECTED_NO_IP = 2,        ///< Connected to wifi, but no IP address
+    CONNECTED = 3,              ///< Connected to wifi with an IP address
+    FAILURE = -1,               ///< Connection failed
+    SSID_NOT_FOUND = -2,        ///< No matching SSID found (could be out of range, or down)
+    AUTHENTICATION_FAILURE = -3 ///< Authentication failure
 };
 
 /**

--- a/src/connectivity/wireless/wifi-connection.cpp
+++ b/src/connectivity/wireless/wifi-connection.cpp
@@ -5,7 +5,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "connectivity/wireless/wifi-connection.hpp"
 
 #include "connectivity/constants.hpp"
-#include "connectivity/detail/wifi-state.hpp"
 
 #include <lwip/ip.h>
 #include <lwip/netif.h>
@@ -19,23 +18,44 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <cstdint>
 #include <string>
 
+inline constexpr uint32_t RECONNECT_TIMEOUT_MS = 60000;
 
-WifiConnection::WifiConnection(std::string_view ssid) : WifiConnection(ssid, std::string_view())
+/**
+ * A RAII-style locking mechanism for the CYW43 lwIP stack.
+ */
+class WifiLock
+{
+public:
+    WifiLock()
+    {
+        cyw43_arch_lwip_begin();
+    }
+
+    ~WifiLock()
+    {
+        cyw43_arch_lwip_end();
+    }
+
+private:
+    WifiLock(const WifiLock&) = delete;
+    WifiLock& operator=(const WifiLock&) = delete;
+};
+
+WifiConnection::WifiConnection(const std::string& hostname, const std::string& ssid) : WifiConnection(hostname, ssid, std::string())
 {}
 
-WifiConnection::WifiConnection(std::string_view ssid, std::string_view passphrase) : _state(nullptr), _address()
+WifiConnection::WifiConnection(const std::string& hostname, const std::string& ssid, const std::string& passphrase)
+    : _address(), _hostname(hostname), _ssid(ssid), _passphrase(passphrase), _interface(nullptr)
 {
+    _interface = &cyw43_state.netif[CYW43_ITF_STA];
     int32_t result = cyw43_arch_init_with_country(CYW43_COUNTRY_USA);
     if (result != PICO_OK) {
         printf("Failed to initialize Wifi: %d\n", result);
         return;
     }
+    cyw43_arch_enable_sta_mode();
 
-    _state = static_cast<WifiState*>(calloc(1, sizeof(WifiState)));
-    if (!_state) {
-        printf("Failed to allocate connection\n");
-        return;
-    }
+    _setHostname();
 
     uint8_t buffer[6];
     cyw43_hal_get_mac(0, buffer);
@@ -43,40 +63,27 @@ WifiConnection::WifiConnection(std::string_view ssid, std::string_view passphras
         _address[i] = buffer[i];
     }
 
-    _connectToWireless(ssid, passphrase);
+    _connectToWireless();
 }
 
 WifiConnection::~WifiConnection()
 {
-    if (_state) {
-        free(_state);
-    }
-
     cyw43_arch_deinit();
 }
 
 std::string WifiConnection::ipAddress() const
 {
-    if (netif_default) {
-        return ipaddr_ntoa(&netif_default->ip_addr);
-    }
-    return std::string(UNKNOWN_IP.data(), UNKNOWN_IP.length());
+    return ipaddr_ntoa(&_interface->ip_addr);
 }
 
 std::string WifiConnection::netmask() const
 {
-    if (netif_default) {
-        return ipaddr_ntoa(&netif_default->netmask);
-    }
-    return std::string(UNKNOWN_IP.data(), UNKNOWN_IP.length());
+    return ipaddr_ntoa(&_interface->netmask);
 }
 
 std::string WifiConnection::gateway() const
 {
-    if (netif_default) {
-        return ipaddr_ntoa(&netif_default->gw);
-    }
-    return std::string(UNKNOWN_IP.data(), UNKNOWN_IP.length());
+    return ipaddr_ntoa(&_interface->gw);
 }
 
 const MACAddress& WifiConnection::macAddress() const
@@ -86,10 +93,26 @@ const MACAddress& WifiConnection::macAddress() const
 
 ConnectionStatus WifiConnection::status() const
 {
-    if (_state) {
-        return _state->status;
+    int32_t status = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
+    switch (status) {
+    case CYW43_LINK_JOIN:
+        if (&_interface->ip_addr.addr > 0) {
+            return ConnectionStatus::CONNECTED;
+        }
+        return ConnectionStatus::CONNECTING;
+    case CYW43_LINK_UP:
+        return ConnectionStatus::CONNECTED;
+    case CYW43_LINK_NOIP:
+        return ConnectionStatus::CONNECTED_NO_IP;
+    case CYW43_LINK_NONET:
+        return ConnectionStatus::SSID_NOT_FOUND;
+    case CYW43_LINK_BADAUTH:
+        return ConnectionStatus::AUTHENTICATION_FAILURE;
+    case CYW43_LINK_FAIL:
+        return ConnectionStatus::FAILURE;
+    default:
+        return ConnectionStatus::NOT_CONNECTED;
     }
-    return ConnectionStatus::INITIALIZATION_FAILURE;
 }
 
 void WifiConnection::poll()
@@ -99,25 +122,36 @@ void WifiConnection::poll()
     cyw43_arch_wait_for_work_until(make_timeout_time_ms(POLL_WAIT_TIME_MS));
 }
 
-void WifiConnection::_connectToWireless(std::string_view ssid, std::string_view passphrase)
+void WifiConnection::reset()
 {
-    _state->status = ConnectionStatus::WIFI_CONNECTING;
-    cyw43_arch_enable_sta_mode();
-    printf("Connecting to Wifi...\n");
+    _connectToWireless();
+}
+
+void WifiConnection::_connectToWireless()
+{
+    WifiLock lock;
+    printf("Connecting to Wifi (SSID: %s)...\n", _ssid.c_str());
 
     int32_t result = INT32_MIN;
-    if (passphrase.size() == 0) {
-        result = cyw43_arch_wifi_connect_timeout_ms(ssid.data(), NULL, CYW43_AUTH_OPEN, WIFI_TIMEOUT_MS);
+    if (_passphrase.size() == 0) {
+        result = cyw43_arch_wifi_connect_timeout_ms(_ssid.c_str(), NULL, CYW43_AUTH_OPEN, WIFI_TIMEOUT_MS);
     }
     else {
-        result = cyw43_arch_wifi_connect_timeout_ms(ssid.data(), passphrase.data(), CYW43_AUTH_WPA2_AES_PSK, WIFI_TIMEOUT_MS);
+        result = cyw43_arch_wifi_connect_timeout_ms(_ssid.c_str(), _passphrase.c_str(), CYW43_AUTH_WPA2_AES_PSK, WIFI_TIMEOUT_MS);
     }
 
     if (result != PICO_OK) {
-        printf("Failed to connect to Wifi: %d\n", result);
-        _state->status = ConnectionStatus::WIFI_CONNECTION_FAILURE;
+        printf("Failed to connect to %s: %d\n", _ssid.c_str(), result);
         return;
     }
 
-    printf("Connected to %s\n", ssid.data());
+    printf("Connected to %s\n", _ssid.c_str());
+    netif_set_up(_interface);
+}
+
+void WifiConnection::_setHostname()
+{
+    WifiLock lock;
+    printf("Setting hostname to %s\n", _hostname.c_str());
+    netif_set_hostname(_interface, _hostname.c_str());
 }

--- a/src/connectivity/wireless/wifi-connection.hpp
+++ b/src/connectivity/wireless/wifi-connection.hpp
@@ -6,10 +6,11 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "connectivity/wireless/connection-status.hpp"
 
+#include <lwip/netif.h>
+
 #include <array>
 #include <cstdint>
 #include <string>
-#include <string_view>
 
 
 struct WifiState; // Forward declaration of WifiState
@@ -25,17 +26,19 @@ public:
     /**
      * Initializes a wireless connection to a wireless network.
      *
+     * @param[in] hostname The Hostname to be used when connecting to @a ssid.
      * @param[in] ssid The SSID of the network to connect to.
      */
-    WifiConnection(std::string_view ssid);
+    WifiConnection(const std::string &hostname, const std::string& ssid);
 
     /**
      * Initializes a wireless connection to a wireless network.
      *
+     * @param[in] hostname The Hostname to be used when connecting to @a ssid.
      * @param[in] ssid The SSID of the network to connect to.
      * @param[in] passphrase The passphrase of the network to connect to.
      */
-    WifiConnection(std::string_view ssid, std::string_view passphrase);
+    WifiConnection(const std::string &hostname, const std::string& ssid, const std::string& passphrase);
 
     /** Destructor */
     ~WifiConnection();
@@ -66,21 +69,31 @@ public:
     ConnectionStatus status() const;
 
     /**
-     * Requests this connection to perform any necessary maintenance tasks on this connection.
+     * Requests this connection to perform any necessary maintenance tasks.
      *
      * This method should be called periodically from the main thread.
      */
     void poll();
 
+    /**
+     * Resets the connection to the SSID.
+     */
+    void reset();
+
 private:
     /**
      * Helper method to connect to the defined wireless network.
-     *
-     * @param[in] ssid The SSID of the network to connect to.
-     * @param[in] passphrase The passphrase of the network to connect to.
      */
-    void _connectToWireless(std::string_view ssid, std::string_view passphrase);
+    void _connectToWireless();
 
-    WifiState* _state;
+    /**
+     * Helper method to set the hostname of this device.
+     */
+    void _setHostname();
+
     MACAddress _address;
+    std::string _hostname;
+    std::string _ssid;
+    std::string _passphrase;
+    struct netif* _interface;
 };


### PR DESCRIPTION
This commit updates the implementation of Wifi to support
the ability to set a `hostname` for a device. By default, this
will be the MQTT device name for simplicity; however, the
`WifiConnection` class will accept any string.

Additionally, this commit fixes a minor bug noticed after
power outages wherein the pico and networking hardware
come up at close to the same time, resulting in the pico
needing to be rebooted. This is addressed by adding the
ability to `reset` the wireless connection.